### PR TITLE
demo paste error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,6 @@ publish = false
 
 [lib]
 crate-type = ["cdylib"]
-name = "lambda"
 
 [dependencies]
-lando = "0.1"
-cpython = "0.1"
+lando = { git = "https://github.com/softprops/lando.git", branch = "paste-test" }

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ plugins:
 custom:
   rust:
     cargoFlags: '--features lando/python3-sys'
+    dockerTag: 'latest'
 package:
   individually: true
   exclude:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate cpython;
-#[macro_use]
 extern crate lando;
 
 // extends http::Request type with api gateway info


### PR DESCRIPTION
this is just a test demoing an error I'm getting with paste mentioned in https://github.com/dtolnay/mashup/pull/18

run `cargo build` and we should get an error like the following


```
 Compiling serverless-lando v0.1.0 (/private/tmp/test-service)
error: macro expansion ignores token `{` and any following
  --> <::paste::expr macros>:2:1
   |
2  |   {
   |   ^
   |
  ::: src/lib.rs:7:1
   |
7  | / gateway!(|request, _| {
8  | |     println!("{:?}", request.path_parameters());
9  | |     Ok(lando::Response::new(format!(
10 | |         "hello {}",
...  |
16 | |     )))
17 | | });
   | |___- caused by the macro expansion here
   |
   = note: the usage of `expr!` is likely invalid in item context
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```